### PR TITLE
Add tool-specific dir into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 
 # cmake
 build/
+
+# tools
+.vscode/


### PR DESCRIPTION
This adds ".vscode/" into .gitignore.

Signed-off-by: Hyun Sik Yoon (Eric Yoon) <hyunsik.yoon.1024@gmail.com>