### PR TITLE
Extract LinkedList as common class

### DIFF
--- a/include/108-ReverseLinkedList.h
+++ b/include/108-ReverseLinkedList.h
@@ -1,39 +1,12 @@
 #ifndef __108__REVERSE_LINKED_LIST__
 #define __108__REVERSE_LINKED_LIST__
 
+#include "LinkedList.h"
+
 namespace n108 
 {
 
-class Node
-{
-public:    
-    Node(int v) : _val(v), _next(nullptr) { /* empty */ }
-    
-    int val() { return this->_val; }
-    Node* next() { return this->_next; }
-
-    void val(int v) { this->_val = v; }
-    void next(Node* const node) { this->_next = node; }
-private:
-    int _val;
-    Node* _next;
-};
-
-class LinkedList
-{
-public:    
-    LinkedList() : _head(nullptr), _tail(nullptr) { /* empty */ }
-
-    Node* head() { return this->_head; };
-    Node* tail() { return this->_tail; };
-    void head(Node* node) { this->_head = node; };
-    void tail(Node* node) { this->_tail = node; };
-private:
-    Node* _head;
-    Node* _tail;
-};
-
-void reverse(LinkedList* l);
+void reverse(ds::LinkedList* l);
 
 } // namespace n108
 

--- a/include/LinkedList.h
+++ b/include/LinkedList.h
@@ -1,0 +1,39 @@
+#ifndef __LINKED_LIST__
+#define __LINKED_LIST__
+
+namespace ds
+{
+
+class Node
+{
+public:    
+    Node(int v) : _val(v), _next(nullptr) { /* empty */ }
+    
+    int val() { return this->_val; }
+    Node* next() { return this->_next; }
+
+    void val(int v) { this->_val = v; }
+    void next(Node* const node) { this->_next = node; }
+private:
+    int _val;
+    Node* _next;
+};
+
+class LinkedList
+{
+public:    
+    LinkedList() : _head(nullptr), _tail(nullptr) { /* empty */ }
+
+    Node* head() { return this->_head; };
+    Node* tail() { return this->_tail; };
+    void head(Node* node) { this->_head = node; };
+    void tail(Node* node) { this->_tail = node; };
+private:
+    Node* _head;
+    Node* _tail;
+};
+
+} // namespace ds
+
+
+#endif //  __LINKED_LIST__

--- a/src/108-ReverseLinkedList.cpp
+++ b/src/108-ReverseLinkedList.cpp
@@ -3,15 +3,15 @@
 namespace n108
 {
 
-void reverse(LinkedList* l)
+void reverse(ds::LinkedList* l)
 {
     if (l == nullptr || l->head() == nullptr) 
     {
         return;
     }
 
-    Node* evantual_tail = l->head();
-    Node* new_head = l->head()->next();
+    ds::Node* evantual_tail = l->head();
+    ds::Node* new_head = l->head()->next();
 
     while (new_head != nullptr)
     {

--- a/src/108-ReverseLinkedList.test.cpp
+++ b/src/108-ReverseLinkedList.test.cpp
@@ -6,7 +6,7 @@ TEST(Reverse_Linked_List_test, empty)
 {
     using namespace n108;
 
-    LinkedList l;
+    ds::LinkedList l;
 
     reverse(&l);
 
@@ -18,8 +18,8 @@ TEST(Reverse_Linked_List_test, one_node)
 {
     using namespace n108;
 
-    LinkedList l;
-    Node node(1);
+    ds::LinkedList l;
+    ds::Node node(1);
 
     l.head(&node);
     l.tail(&node);
@@ -34,10 +34,10 @@ TEST(Reverse_Linked_List_test, three_node)
 {
     using namespace n108;
 
-    LinkedList l;
-    Node node1(1);
-    Node node2(2);
-    Node node3(3);
+    ds::LinkedList l;
+    ds::Node node1(1);
+    ds::Node node2(2);
+    ds::Node node3(3);
 
     node1.next(&node2);
     node2.next(&node3);


### PR DESCRIPTION
This extract `LinkedList` and `Node` as common classes before writing `Stack` and `Queue`, which will use `LinkedList`.

Signed-off-by: Hyun Sik Yoon (Eric Yoon) <hyunsik.yoon.1024@gmail.com>