### PR TITLE
Add insert() for binary search tree in chapter 132.

### DIFF
--- a/include/132-BinarySearchTree.h
+++ b/include/132-BinarySearchTree.h
@@ -1,0 +1,93 @@
+#ifndef __132__BINARY_SEARCH_TREE__
+#define __132__BINARY_SEARCH_TREE__
+
+#include <stdexcept>
+#include <vector>
+
+namespace n132
+{
+
+template <typename T> class Node
+{
+public:
+    Node(const T &val): _val(val), _left(nullptr), _right(nullptr) { /* empty */ }
+
+    using NodeP = Node *;
+
+    // For expression like `node->left() = new Node(0);`
+    NodeP &left() { return _left; }
+    NodeP &right() { return _right; }
+
+    const T val() { return _val; }
+private:
+    const T _val;
+    Node *_left;
+    Node *_right;
+};
+
+template <typename T> class BinarySearchTree
+{
+public:
+    BinarySearchTree() { _root = nullptr; }
+
+    void insert(const T &item)
+    {
+        if (is_empty())
+        {
+            _root = new Node<T>(item);
+            return;
+        }
+
+        for (auto r = _root; ;)
+        {
+            if (item == r->val())
+            {
+                // already existing value. Do not add.
+                return;
+            }
+            else if (item < r->val())
+            {
+                if (r->left() == nullptr)
+                {
+                    r->left() = new Node<T>(item);
+                    return;
+                }
+                else
+                {
+                    r = r->left();
+                }
+            }
+            else if (item > r->val())
+            {
+                if (r->right() == nullptr)
+                {
+                    r->right() = new Node<T>(item);
+                    return;
+                }
+                else
+                {
+                    r = r->right();
+                }
+            }
+        }
+    }
+
+    const T remove(const T &item)
+    {
+        throw std::runtime_error("Not yet implemented");
+    }
+
+    bool is_empty()
+    {
+        return (_root == nullptr);
+    }
+
+    Node<T> *root() { return _root; }
+
+private:
+    Node<T> *_root;
+};
+
+} // namespace n132
+
+#endif

--- a/src/132-BinarySearchTree.test.cpp
+++ b/src/132-BinarySearchTree.test.cpp
@@ -1,0 +1,104 @@
+#include "132-BinarySearchTree.h"
+
+#include <gtest/gtest.h>
+#include <algorithm>
+
+namespace debug
+{
+using namespace n132;
+
+template <typename T>
+inline void dump_dfs(Node<T> *root, std::vector<T> &v, T nullptr_marker)
+{
+    v.emplace_back(root->val());
+
+    if (root->left())
+    {
+        dump_dfs(root->left(), v, nullptr_marker);
+    }
+    else
+    {
+        v.emplace_back(nullptr_marker);
+    }
+
+    if (root->right())
+    {
+        dump_dfs(root->right(), v, nullptr_marker);
+    }
+    else
+    {
+        v.emplace_back(nullptr_marker);
+    }
+};
+
+template <typename T>
+inline std::vector<T> dump(BinarySearchTree<T> &bst, T nullptr_marker)
+{
+    std::vector<T> v;
+    if (bst.is_empty())
+    {
+        v.emplace_back(nullptr_marker);
+    }
+    else
+    {
+        dump_dfs(bst.root(), v, nullptr_marker);
+    }
+    return v;
+}
+
+} // namespace debug
+
+TEST(binary_search_tree, empty)
+{
+    using namespace n132;
+    BinarySearchTree<int> bst;
+
+    ASSERT_EQ(bst.is_empty(), true);
+}
+
+TEST(binary_search_tree, insert_1)
+{
+    using namespace n132;
+    BinarySearchTree<int> bst;
+
+    int N =  -1; // nullptr_marker
+    {
+        bst.insert(100);
+
+        ASSERT_EQ(bst.is_empty(), false);
+        auto actual = debug::dump(bst, N);
+
+        std::vector<int> expected = {
+              100,
+             N, N
+        };
+        ASSERT_TRUE(std::equal(actual.begin(), actual.end(), expected.begin()));
+    }
+    {
+        bst.insert(50);
+
+        auto actual = debug::dump(bst, N);
+
+        std::vector<int> expected = {
+               100,
+             50,
+            N, N,
+                   N
+        };
+        ASSERT_TRUE(std::equal(actual.begin(), actual.end(), expected.begin()));
+    }
+    {
+        bst.insert(180);
+
+        auto actual = debug::dump(bst, N);
+
+        std::vector<int> expected = {
+               100,
+             50,
+            N, N,
+                   180,
+                  N,  N
+        };
+        ASSERT_TRUE(std::equal(actual.begin(), actual.end(), expected.begin()));
+    }
+}


### PR DESCRIPTION
This adds `insert()` method and tests for binary search tree in chapter 132.

Signed-off-by: Hyun Sik Yoon (Eric Yoon) <hyunsik.yoon.1024@gmail.com>