### PR TITLE
Add merge sort for chapter 180

### DIFF
--- a/include/170-191-Sorting.h
+++ b/include/170-191-Sorting.h
@@ -10,6 +10,7 @@ namespace sorting
 template <typename T> void bubble_sort(std::vector<T> &v);
 template <typename T> void selection_sort(std::vector<T> &v);
 template <typename T> void insertion_sort(std::vector<T> &v);
+template <typename T> const std::vector<T> merge_sort(const std::vector<T> &v);
 
 } // namespace sorting
 

--- a/src/170-191-Sorting.cpp
+++ b/src/170-191-Sorting.cpp
@@ -1,5 +1,7 @@
 #include "170-191-Sorting.h"
 
+#include <cassert>
+#include <stdexcept>
 #include <stdint.h>
 
 namespace
@@ -74,9 +76,92 @@ template <typename T> void insertion_sort(std::vector<T> &v)
     }
 }
 
+} // namespace sorting
+
+
+// For merge Sort
+namespace
+{
+
+template <typename T> const std::vector<T> merge(const std::vector<T> &left, const std::vector<T> &right)
+{
+    uint32_t v_size = left.size() + right.size();
+    std::vector<T> vec(v_size);
+
+    uint32_t l = 0;  // for index of left vector
+    uint32_t r = 0;  // for index of right vector
+    uint32_t v = 0;  // for index of returned vector
+
+    while (true)
+    {
+        if (left[l] < right[r])
+        {
+            vec[v] = left[l];
+            l++;
+            v++;
+        }
+        else
+        {
+            vec[v] = right[r];
+            r++;
+            v++;
+        }
+
+        if (l == left.size())
+        {
+            // copy rest of right
+            for (auto i = r; i < right.size(); i++, v++)
+            {
+                vec[v] = right[i];
+            }
+            break;
+        }
+        if (r == right.size())
+        {
+            // copy rest of left
+            for (auto i = l; i < left.size(); i++, v++)
+            {
+                vec[v] = left[i];
+            }
+            break;
+        }
+    }
+    return vec;
+}
+
+} // namespace
+
+namespace sorting
+{
+
+template <typename T> const std::vector<T> merge_sort(const std::vector<T> &v)
+{
+    if (v.size() <= 1)
+    {
+        return v;
+    }
+
+    int32_t mid_idx = v.size() / 2;
+    //   Example
+    //       size()        mid_idx
+    //          4            2
+    //          5            2
+
+    const auto left_v = merge_sort(std::vector<T>{v.begin(), v.begin() + mid_idx});
+    const auto right_v = merge_sort(std::vector<T>{v.begin() + mid_idx, v.end()});
+
+    return merge(left_v, right_v);
+}
+
+} // namespace sorting
+
 // template instantiation
+namespace sorting
+{
+
 template void bubble_sort<uint32_t>(std::vector<uint32_t> &v);
 template void selection_sort<uint32_t>(std::vector<uint32_t> &v);
 template void insertion_sort<uint32_t>(std::vector<uint32_t> &v);
+template const std::vector<uint32_t> merge_sort(const std::vector<uint32_t> &v);
 
 } // namespace sorting

--- a/src/170-191-Sorting.test.cpp
+++ b/src/170-191-Sorting.test.cpp
@@ -36,3 +36,10 @@ TEST(sorting_test, insertion_sort_test)
 
     ASSERT_TRUE(std::equal(expected.begin(), expected.end(), actual.begin()));
 }
+
+TEST(sorting_test, merge_sort_test)
+{
+    auto actual = sorting::merge_sort(data);
+
+    ASSERT_TRUE(std::equal(expected.begin(), expected.end(), actual.begin()));
+}


### PR DESCRIPTION
This adds merge sort and a test case for chapter 180.

This creates internally roughly one more copy of input vector while creating trees throuout recursion.
I was trying to implement without copying but it was kinda hard.

Signed-off-by: Hyun Sik Yoon (Eric Yoon) <hyunsik.yoon.1024@gmail.com>