### PR TITLE
Fix wrong template type of Queue

### DIFF
--- a/include/122-Queue.h
+++ b/include/122-Queue.h
@@ -43,7 +43,7 @@ public:
     }
 
 private:
-    ds::LinkedList<int> _l;
+    ds::LinkedList<T> _l;
 };
 
 /**


### PR DESCRIPTION
This fix wrong template type (`int`) to generic type(`T`).

Signed-off-by: Hyun Sik Yoon (Eric Yoon) <hyunsik.yoon.1024@gmail.com>